### PR TITLE
Change build to Portable image

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,7 @@
   "shortDescription": "mev-boost allows proof-of-stake Ethereum consensus clients to outsource block construction",
   "description": "mev-boost allows validators in Ethereum proof-of-stake to request blocks from a network of builders.\nThis project is part of the Flashbots research towards proposer/builder separation for Maximal Extractable Value (MEV) mitigation. mev-boost can connect to relays that aggregate multiple builders. The builders prepare full blocks, optimizing for MEV extraction and fair distribution of the rewards. The Consensus Layer client of the validator proposes the most profitable block received from mev-boost.",
   "upstreamRepo": "flashbots/mev-boost",
-  "upstreamVersion": "v1.4.0",
+  "upstreamVersion": "v1.4.0-portable",
   "upstreamArg": "UPSTREAM_VERSION",
   "type": "service",
   "author": "Nabsku <thenabsku@gmail.com> (https://github.com/Nabsku)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: src
       args:
-        UPSTREAM_VERSION: 1.5.0-portable
+        UPSTREAM_VERSION: 1.5.0
     volumes:
       - "data:/var/lib/mev-boost"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: src
       args:
-        UPSTREAM_VERSION: v1.4.0
+        UPSTREAM_VERSION: 1.4.0
     volumes:
       - "data:/var/lib/mev-boost"
     environment:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 ARG UPSTREAM_VERSION
-FROM flashbots/mev-boost:${UPSTREAM_VERSION}
+FROM flashbots/mev-boost:${UPSTREAM_VERSION}-portable
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
Test the portable build to resolve `SIGILL: illegal instruction` errors users are having, its common and flashbots says to use the portable build either from docker or built from source to resolve.