### PR TITLE
feat: enable arm64 builds

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,7 +9,7 @@
   "type": "service",
   "author": "Nabsku <thenabsku@gmail.com> (https://github.com/Nabsku)",
   "contributors": ["Nabsku <thenabsku@gmail.com> (https://github.com/Nabsku)"],
-  "architectures": ["linux/amd64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "categories": ["Economic incentive"],
   "links": {
     "endpoint": "http://mev-boost.mev-boost.dappnode:18550",


### PR DESCRIPTION
This PR enables arm64 builds for mev-boost. It depends on this SDK PR: https://github.com/dappnode/DAppNodeSDK/pull/390